### PR TITLE
Temporarily disable Bluesky link in navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="http://steren.fr" rel="me nofollow">Web</a> - <a href="http://blog.steren.fr" rel="me nofollow">Blog</a> - <a href="http://labs.steren.fr" rel="me nofollow">Labs</a> - <a href="http://talks.steren.fr" rel="me nofollow">Talks</a> - <a href="https://twitter.com/steren" rel="me nofollow">Twitter</a> - <a href="https://bsky.app/profile/steren.fr" rel="me">Bluesky</a> - <a href="https://www.linkedin.com/in/steren" rel="me nofollow">LinkedIn</a>
+<a href="http://steren.fr" rel="me nofollow">Web</a> - <a href="http://blog.steren.fr" rel="me nofollow">Blog</a> - <a href="http://labs.steren.fr" rel="me nofollow">Labs</a> - <a href="http://talks.steren.fr" rel="me nofollow">Talks</a> - <a href="https://twitter.com/steren" rel="me nofollow">Twitter</a><!-- - <a href="https://bsky.app/profile/steren.fr" rel="me">Bluesky</a> --> - <a href="https://www.linkedin.com/in/steren" rel="me nofollow">LinkedIn</a>
 
 👋 Hi,  
 

--- a/index.html
+++ b/index.html
@@ -318,7 +318,7 @@
           <li><a href="http://labs.steren.fr" target="_blank" rel="me">Labs</a></li>
           <li><a href="http://talks.steren.fr" target="_blank" rel="me">Talks</a></li>
           <li><a href="https://twitter.com/steren" target="_blank" rel="me">Twitter</a></li>
-          <li><a href="https://bsky.app/profile/steren.fr" target="_blank" rel="me">Bluesky</a></li>
+          <!-- <li><a href="https://bsky.app/profile/steren.fr" target="_blank" rel="me">Bluesky</a></li> -->
           <li><a href="https://www.linkedin.com/in/steren" target="_blank" rel="me">LinkedIn</a></li>
           <li><a href="https://github.com/steren" target="_blank" rel="me">GitHub</a></li>
         </ul>


### PR DESCRIPTION
## Summary
This PR temporarily disables the Bluesky social media link from both the README and main website navigation by commenting out the relevant HTML elements.

## Changes
- **README.md**: Commented out the Bluesky link in the header navigation bar
- **index.html**: Commented out the Bluesky list item in the footer navigation menu

## Details
Both changes use HTML comments to preserve the code while removing it from display, allowing for easy re-enablement in the future if needed. The Bluesky profile link (https://bsky.app/profile/steren.fr) remains in the codebase but is no longer visible to users.

https://claude.ai/code/session_011PrTmD2sKKDNdNcDpcQHch