### PR TITLE
Add main landmark for accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -326,7 +326,7 @@
     </div>
   </header>
 
-  <div class="container">
+  <main class="container">
     <section id="intro">
       <div class="card">
         <div class="logo-container">
@@ -527,5 +527,5 @@
             </steren-work>
         </div>
     </section>
-  </div>
+  </main>
 </body></html>


### PR DESCRIPTION
Addresses the Lighthouse / axe finding **"Document does not have a main landmark"** ([landmark-one-main](https://dequeuniversity.com/rules/axe/4.12/landmark-one-main)).

## Change

One element, `index.html`: the wrapper `<div class="container">` holding the intro and works sections is now `<main class="container">`.

The page already had a `<header>` (banner landmark), but all the primary content sat in a plain `div`, so screen reader users had no main landmark to jump to.

Keeping the `container` class means the existing layout CSS applies unchanged, and `<main>` is `display: block` by default — so this is a semantics-only change.

## Verification

**axe-core, landmark rules, before vs. after:**

| Rule | Before | After |
| --- | --- | --- |
| `landmark-one-main` | ❌ violation | ✅ pass |
| `region` | ❌ 10 violations | ✅ pass |
| `landmark-unique` | ✅ pass | ✅ pass |
| `landmark-no-duplicate-main` | n/a | ✅ pass |

Wrapping the content also resolved 10 `region` violations (content not contained within landmarks) — every element now sits inside either the banner or main.

**No visual regression.** Rendered before and after in Chromium at desktop (1280×900) and mobile (390×844), in both light and dark schemes:

- Layout geometry (`#intro` and `#work-list` bounding boxes, document scroll width/height) is identical to the sub-pixel across all four combinations.
- With JavaScript disabled, the screenshots are **byte-for-byte identical** in all four combinations.

The JS-disabled comparison is the meaningful one here: with `rtx-on` active, its WebGL path-traced lighting is nondeterministic — rendering the *same unmodified file* twice produces an 80.8% pixel difference, so a naive before/after pixel diff on this page is all noise. Disabling JS removes that source of variance, and since the page has no layout JavaScript, it isolates exactly the DOM/CSS change. The page was also rendered with `rtx-on` active to confirm the lighting effect still looks correct.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRENiBPbUif3cByVdXRUr8)_