### PR TITLE
Increase card border radius and clip content to rounded corners

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,7 +130,9 @@
       background-color: light-dark(white, rgb(255 255 255 / 5%));
       box-shadow: 0 2px 5px 0 rgb(0 0 0 / 26%);
       margin: 1rem;
-      border-radius: 2px;
+      border-radius: 8px;
+      /* clip the media, which fills the card edge to edge, to the rounded corners */
+      overflow: hidden;
     }
 
     /* aspect-ratio reserves the image box before the image is downloaded */


### PR DESCRIPTION
## Summary
Updated the card styling to use more prominent rounded corners and ensure content respects the border radius by adding overflow clipping.

## Changes
- Increased `border-radius` from `2px` to `8px` for a more modern, rounded appearance
- Added `overflow: hidden` to clip child elements (media) to the rounded corners, preventing content from extending beyond the card's border radius

## Implementation Details
The `overflow: hidden` property is necessary because the media content (likely images) fills the card edge-to-edge. Without this clipping, the media would visually extend beyond the rounded corners, creating a misaligned appearance. This ensures a polished, cohesive card design where all content respects the defined border radius.

https://claude.ai/code/session_01UGVcLErLrbiG5bsUiZZQbw