### PR TITLE
Replace Cloud Error Reporting with Beansight project card

### DIFF
--- a/index.html
+++ b/index.html
@@ -283,7 +283,7 @@
           </a>
         </li>
         <li class="card" data-id="beansight" data-featured="true" data-size="10" data-completion="done" data-seriousness="serious" data-type="code" data-participation="lead" data-category="web" data-date="2011">
-          <a href="https://github.com/beansight/beansight-website" title="Beansight source code" target="_blank" rel="noopener">
+          <a href="https://www.beansight.com" title="Beansight website" target="_blank" rel="noopener">
             <img class="logo" src="img/logos/beansight.svg" alt="Beansight logo">
             <h3>Beansight</h3>
             <p>Prediction market.</p>

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
   <link rel="preload" href="img/icons/carbon-footprint-screenshot.webp" as="image" fetchpriority="high">
   <link rel="preload" href="img/icons/cloud-run.svg" as="image" fetchpriority="high">
   <link rel="preload" href="img/loops/cloud-run.svg" as="image">
-  <link rel="preload" href="img/icons/error-reporting-screenshot.webp" as="image" fetchpriority="high">
+  <link rel="preload" href="img/logos/beansight.svg" as="image" fetchpriority="high">
   <link rel="preload" href="img/logos/factory.svg" as="image" fetchpriority="high">
   <link rel="preload" href="img/icons/cadeaux.svg" as="image" fetchpriority="high">
   <link rel="preload" href="img/icons/capoda.webp" as="image" fetchpriority="high">
@@ -282,11 +282,11 @@
             <p>Understand and reduce Google Cloud carbon emissions.</p>
           </a>
         </li>
-        <li class="card" data-id="error-reporting" data-featured="true" data-size="20" data-completion="done" data-seriousness="serious" data-type="product" data-participation="contribution" data-category="web" data-date="2016">
-          <a href="https://cloud.google.com/error-reporting/" title="Cloud Error Reporting product page" target="_blank" rel="noopener">
-            <img class="image screenshot" loading="lazy" src="img/icons/error-reporting-screenshot.webp" alt="Cloud Error Reporting screenshot">
-            <h3>Cloud Error Reporting</h3>
-            <p>Identify and understand application errors.</p>
+        <li class="card" data-id="beansight" data-featured="true" data-size="10" data-completion="done" data-seriousness="serious" data-type="code" data-participation="lead" data-category="web" data-date="2011">
+          <a href="https://github.com/beansight/beansight-website" title="Beansight source code" target="_blank" rel="noopener">
+            <img class="logo" src="img/logos/beansight.svg" alt="Beansight logo">
+            <h3>Beansight</h3>
+            <p>Co-founder of a web start-up that predicts the future.</p>
           </a>
         </li>
         <li class="card" data-id="factory" data-featured="true" data-size="15" data-completion="done" data-seriousness="serious" data-type="product" data-participation="lead" data-category="web" data-date="2012">

--- a/index.html
+++ b/index.html
@@ -286,7 +286,7 @@
           <a href="https://github.com/beansight/beansight-website" title="Beansight source code" target="_blank" rel="noopener">
             <img class="logo" src="img/logos/beansight.svg" alt="Beansight logo">
             <h3>Beansight</h3>
-            <p>Co-founder of a web start-up that predicts the future.</p>
+            <p>Prediction market.</p>
           </a>
         </li>
         <li class="card" data-id="factory" data-featured="true" data-size="15" data-completion="done" data-seriousness="serious" data-type="product" data-participation="lead" data-category="web" data-date="2012">


### PR DESCRIPTION
## Summary
This change replaces the Cloud Error Reporting product card with a Beansight project card in the portfolio section of the website.

## Key Changes
- Updated preload link from `error-reporting-screenshot.webp` to `beansight.svg` logo
- Replaced Cloud Error Reporting card with Beansight card:
  - Changed data attributes: `data-id`, `data-size`, `data-type`, `data-participation`, and `data-date`
  - Updated image from screenshot to logo format (changed class from `screenshot` to `logo`)
  - Changed link destination from Google Cloud product page to Beansight GitHub repository
  - Updated card title and description to reflect Beansight project
  - Changed participation level from "contribution" to "lead"
  - Changed project type from "product" to "code"
  - Updated project date from 2016 to 2011

## Notable Details
- The card maintains the "featured" status and "serious" seriousness level
- Image asset changed from WebP screenshot to SVG logo format
- Project category remains "web"
- Size reduced from 20 to 10 units

https://claude.ai/code/session_01VJ3PjGRtC1ieaGSXS8oGET