### PR TITLE
Sync the README with the work list and tighten card taglines

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ I [tweet](https://twitter.com/steren), [talk](https://talks.steren.fr), [experim
 
 <a href="https://cloud.run"><img src="img/icons/carbon-footprint-screenshot.webp" width="200" height="152"></a>  
 **[Cloud Carbon Footprint](https://cloud.google.com/carbon-footprint)**  
-Understand and reduce your Google Cloud carbon emissions.
+Greenhouse gas reporting.
 
 <a href="https://cloud.run"><img src="img/icons/cloud-run.svg" width="200" height="100"></a>  
 **[Cloud Run](https://cloud.run)**  

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ I [tweet](https://twitter.com/steren), [talk](https://talks.steren.fr), [experim
 Greenhouse gas reporting.
 
 <a href="https://cloud.run"><img src="img/icons/cloud-run.svg" width="200" height="100"></a>  
-**[Cloud Run](https://cloud.run)**  
-Google Cloud's serverless runtime.
+**[Google Cloud Run](https://cloud.run)**  
+Serverless runtime.
 
 <a href="https://www.beansight.com"><img src="img/logos/beansight.svg" width="100" height="100"></a>  
 **[Beansight](https://www.beansight.com)**  

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Understand and reduce your Google Cloud carbon emissions.
 **[Cloud Run](https://cloud.run)**  
 Google Cloud's serverless runtime.
 
-<a href="https://cloud.google.com/error-reporting/"><img src="img/icons/error-reporting-screenshot.webp" width="200" height="100"></a>  
-**[Cloud Error Reporting](https://cloud.google.com/error-reporting/)**  
-Identify and understand application errors.
+<a href="https://www.beansight.com"><img src="img/logos/beansight.svg" width="100" height="100"></a>  
+**[Beansight](https://www.beansight.com)**  
+Prediction market.
 
 <a href="https://www.dailymotion.com/video/xuy6pq"><img src="img/logos/factory.svg" width="100" height="100"></a>  
 **[Joshfire Factory](https://www.dailymotion.com/video/xuy6pq)**  

--- a/index.html
+++ b/index.html
@@ -279,7 +279,7 @@
           <a href="https://cloud.google.com/carbon-footprint/" title="Cloud Carbon Footprint website" target="_blank" rel="noopener">
             <img class="image screenshot" loading="lazy" src="img/icons/carbon-footprint-screenshot.webp" alt="Cloud Carbon Footprint screenshot">
             <h3>Cloud Carbon Footprint</h3>
-            <p>Understand and reduce Google Cloud carbon emissions.</p>
+            <p>Greenhouse gas reporting.</p>
           </a>
         </li>
         <li class="card" data-id="beansight" data-featured="true" data-size="10" data-completion="done" data-seriousness="serious" data-type="code" data-participation="lead" data-category="web" data-date="2011">

--- a/index.html
+++ b/index.html
@@ -268,11 +268,11 @@
     <section id="works">
       <ol id="work-list">
         <li class="card" data-id="cloud-run" data-featured="true" data-size="50" data-completion="in-progress" data-seriousness="serious" data-type="product" data-participation="lead" data-category="" data-date="2019">
-          <a href="https://cloud.google.com/run/" title="Cloud Run website" target="_blank" rel="noopener">
+          <a href="https://cloud.google.com/run/" title="Google Cloud Run website" target="_blank" rel="noopener">
             <img class="image screenshot" src="img/icons/cloud-run.svg" alt="Cloud Run command line">
             <img class="loop screenshot" loading="lazy" src="img/loops/cloud-run.svg" alt="Cloud Run command line">
-            <h3>Cloud Run</h3>
-            <p>Google Cloud's serverless runtime.</p>
+            <h3>Google Cloud Run</h3>
+            <p>Serverless runtime.</p>
           </a>
         </li>
         <li class="card" data-id="carbon-footprint" data-featured="true" data-size="20" data-completion="in-progress" data-seriousness="serious" data-type="product" data-participation="lead" data-category="" data-date="2021">


### PR DESCRIPTION
Follow-up to #13, which featured Beansight on the site but left the README's copy of the work list untouched.

### README: Beansight replaces Cloud Error Reporting
Same slot the site uses, so the two lists stay in the same order. Uses `img/logos/beansight.svg` at 100×100 — the SVG is square, matching the Joshfire Factory logo entry rather than the 200×100 screenshot entries — and links to beansight.com with the "Prediction market." tagline.

### Cloud Carbon Footprint tagline
"Understand and reduce Google Cloud carbon emissions." → **"Greenhouse gas reporting."**

It was the only tagline written as an imperative verb phrase; every other card is a short noun phrase naming what the thing is. It was also the only one repeating a word from its own title. The README's variant had an extra "your"; both files now read identically.

### Cloud Run card renamed
Title "Cloud Run" → **"Google Cloud Run"**, tagline "Google Cloud's serverless runtime." → **"Serverless runtime."** — the qualifier moves into the title instead of the tagline. The link's `title` attribute was updated to match the heading.

Left alone deliberately: `data-id="cloud-run"` (internal identifier, not display text) and the image `alt`s, which describe the screenshot ("Cloud Run command line") rather than name the product. `img/icons/error-reporting-screenshot.webp` also stays in the repo, consistent with other retired cards' assets.

No behavior or layout changes — copy, one image swap, and the matching preload link from #13.